### PR TITLE
Release 2026.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push docker image to registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           platforms: ${{ vars.DOCKER_PLATFORMS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to docker registry
         uses: docker/login-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
-## What’s changed
- => https://github.com/tdenolle/bayrol-poolaccess-mqtt/releases/latest
+# Changelog
+
+## What's changed
+
+=> [https://github.com/tdenolle/bayrol-poolaccess-mqtt/releases/latest](https://github.com/tdenolle/bayrol-poolaccess-mqtt/releases/latest)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Bayrol PoolAccess to MQTT
 
-
-![Supports arm64 Architecture][arm64-shield] 
-![Supports amd64 Architecture][amd64-shield] 
-![Supports armv6 Architecture][armv6-shield] 
+![Supports arm64 Architecture][arm64-shield]
+![Supports amd64 Architecture][amd64-shield]
+![Supports armv6 Architecture][armv6-shield]
 ![Supports armv7 Architecture][armv7-shield]
 
 ![License](https://img.shields.io/github/license/tdenolle/bayrol-poolaccess-mqtt)
@@ -11,7 +10,7 @@
 
 ![Bayrol Automatic Salt](docs/bayrol_automatic_salt_connect.png)
 
-### Bayrol PoolAccess (eg Automatic Salt Products) to MQTT Bridge
+## Bayrol PoolAccess (eg Automatic Salt Products) to MQTT Bridge
 
 **bayrol-poolaccess-mqtt** allows you to connect to bayrol poolaccess server and publish data to your Home Assistant Mqtt broker.
 

--- a/app/PoolAccessMqttBridge.py
+++ b/app/PoolAccessMqttBridge.py
@@ -131,25 +131,25 @@ class PoolAccessMqttBridge:
             poolaccess_status = self._poolaccess_client.loop(timeout)
 
             if broker_status != MQTT_ERR_SUCCESS:
-                self._logger.warning(
+                self._logger.info(
                     "Broker Client has been disconnected [status: %s] : trying to reconnect ...", broker_status
                 )
                 try:
                     self._broker_client.reconnect()
                 except Exception as e:
                     self._logger.error("Reconnect exception occurred %s ...", str(e))
-                self._logger.info("Waiting %ss ...", str(self._reconnect_delay))
+                self._logger.info("Waiting %ss for reconnection...", str(self._reconnect_delay))
                 time.sleep(self._reconnect_delay)
 
             if poolaccess_status != MQTT_ERR_SUCCESS:
-                self._logger.warning(
+                self._logger.info(
                     "Poolaccess Client has been disconnected [status: %s] : trying to reconnect ...", poolaccess_status
                 )
                 try:
                     self._poolaccess_client.reconnect()
                 except Exception as e:
                     self._logger.error("Reconnect exception occurred %s ...", str(e))
-                self._logger.info("Waiting %ss ...", str(self._reconnect_delay))
+                self._logger.info("Waiting %ss for reconnection...", str(self._reconnect_delay))
                 time.sleep(self._reconnect_delay)
 
             # loop exit condition

--- a/app/PoolAccessMqttBridge.py
+++ b/app/PoolAccessMqttBridge.py
@@ -176,7 +176,7 @@ class PoolAccessMqttBridge:
 
         # Multithreading startup if connection_success
         if connection_success:
-            self._logger.info("Starting Multithreading")
+            self._logger.info("Starting Multithreading...")
             t = threading.Thread(target=self._multi_loop, args=())  # start multi loop
             t.start()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.3.0"
+version = "2026.3.1"
 name = "bayrol-poolaccess-mqtt"
 requires-python = ">= 3.13"
 authors = [


### PR DESCRIPTION
## Release 2026.3.1

### Changes
- feat: support `{id}` placeholder in `UPDATE_VERSION_ENDPOINT`
- feat: add `UPDATE_VERSION_ENDPOINT` to Dockerfile and CI configuration
- feat: add debug logs to `HttpErrorHandler`
- feat: lower `HttpErrorHandler` default level to WARNING
- fix: handle missing `UPDATE_VERSION_ENDPOINT` environment variable
- fix: rename `ERROR_REPORTING_URL` to `ERROR_REPORTING_ENDPOINT` for consistency
- fix: downgrade filter skipping logs from WARNING to INFO
- fix: set `HttpErrorHandler` default level to ERROR
- refactor: change warning logs to info for broker and poolaccess reconnection attempts
- refactor: add ellipsis to multithreading startup log message
- chore: switch versioning to CalVer (YEAR.MONTH.INCREMENT)
- chore: update deps (docker/build-push-action v7, docker/setup-buildx-action v4, docker/login-action v4, docker/setup-qemu-action v4, actions/upload-artifact v7)
- chore: require paho-mqtt 2.1.0, update to Python 3.13 and latest dependencies
- chore: add COPILOT_RULES.md
