### PR TITLE
Release 2026.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ vars.PYTHON_VERSION }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build, test and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ vars.PYTHON_VERSION }}
         uses: actions/setup-python@v6
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Read version from toml
         id: toml_version
@@ -186,7 +186,7 @@ jobs:
           fi
 
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ vars.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ vars.PYTHON_VERSION }}
 
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ vars.PYTHON_VERSION }}
 

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -64,6 +64,5 @@
   "mv_dos_rate": "Chlor-Dosierung",
   "sw_version": "Firmware",
   "control_box_used": "Smart & Easy Box",
-  "use_vsp": "Drehzahlpumpe verwenden",
-  "e_enum_use_vsp": "Variable Drehzahlpumpe verwenden"
+  "use_vsp": "Variable Drehzahlpumpe verwenden"
 }

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -65,6 +65,5 @@
   "ph_minus_canister_status": "pH- Canister",
   "mv_dos_rate": "Chlorine Dosage",
   "control_box_used": "Smart & Easy Box",
-  "use_vsp": "Variable Speed Pump",
-  "e_enum_use_vsp": "Variable Speed Pump"
+  "use_vsp": "Variable Speed Pump"
 }

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -64,6 +64,5 @@
   "ph_minus_canister_status": "Bidón pH-",
   "mv_dos_rate": "Dosificación Cloro",
   "control_box_used": "Smart & Easy Box",
-  "use_vsp": "Usar bomba de velocidad variable",
-  "e_enum_use_vsp": "Bomba de Velocidad Variable"
+  "use_vsp": "Bomba de Velocidad Variable"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "paho-mqtt==2.1.0",
     "docopt",
     "requests==2.33.1",
-    "tomlkit==0.14.0"
+    "tomlkit==0.15.0"
 ]
 classifiers=[
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {file = "LICENSE"}
 dependencies = [
     "paho-mqtt==2.1.0",
     "docopt",
-    "requests==2.33.1",
+    "requests==2.34.2",
     "tomlkit==0.15.0"
 ]
 classifiers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "paho-mqtt==2.1.0",
     "docopt",
     "requests==2.34.2",
-    "tomlkit==0.15.0"
+    "tomlkit==0.15.1"
 ]
 classifiers=[
     'Development Status :: 5 - Production/Stable',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2026.5.0"
+version = "2026.7.0"
 name = "bayrol-poolaccess-mqtt"
 requires-python = ">= 3.13"
 authors = [


### PR DESCRIPTION
## Release 2026.7.0

Publication de la version **2026.7.0** (`develop` → `master`).

### Changements
- **i18n** : suppression des clés de traduction obsolètes `e_enum_use_vsp`
- **chore** : bump de version en `2026.7.0`

### Mises à jour de dépendances
- `requests` → 2.34.2
- `tomlkit` → 0.15.1
- `actions/checkout` → v7
- `actions/setup-node` → v7
- `actions/setup-python` → v7

### Tests
- 118 tests unitaires au vert
